### PR TITLE
Fix for windows boottime to convert returned string format to a times…

### DIFF
--- a/src/Runtime/Windows/Boottime.php
+++ b/src/Runtime/Windows/Boottime.php
@@ -9,6 +9,10 @@ class Boottime implements RuntimeInterface
 
     public function read($command = 'wmic os get lastbootuptime')
     {
-        return trim( explode( "\n", shell_exec($command) )[1] );
+        $dateTime = \DateTime::createFromFormat(
+            'YmdHis.uO',
+            trim( explode( "\n", shell_exec($command) )[1] )
+        );
+        return $dateTime->getTimestamp();
     }
 }

--- a/test/Runtime/Windows/BoottimeTest.php
+++ b/test/Runtime/Windows/BoottimeTest.php
@@ -22,14 +22,14 @@ class BoottimeTest extends \PHPUnit_Framework_TestCase
 
     public function stdinProvider()
     {
-        $factory = function ($timestamp, $stdout) {
-            return [ $timestamp, sprintf($stdout, $timestamp) ];
+        $factory = function ($timestamp, $inputString, $stdout) {
+            return [ $timestamp, sprintf($stdout, $inputString) ];
         };
 
         return [
-            $factory('20140429225056.153625-180', "LastBootUpTime\n%s\n\n\n"),
-            $factory('20120612125056.153625-060', "LastBootUpTime\n%s\n\n\n"),
-            $factory('20130921162204.153625+120', "LastBootUpTime\n%s\n\n\n"),
+            $factory(1398820256, '20140429225056.153625-180', "LastBootUpTime\n%s\n\n\n"),
+            $factory(1339509056, '20120612125056.153625-060', "LastBootUpTime\n%s\n\n\n"),
+            $factory(1379775724, '20130921162204.153625+120', "LastBootUpTime\n%s\n\n\n"),
         ];
     }
 }


### PR DESCRIPTION
I noticed that `wmic os get lastbootuptime` returns a string format rather than a unix timestamp. Therefore I've modified the boottime method for Windows.