### PR TITLE
Fixed problem with windows last boot time and multiple timezones

### DIFF
--- a/src/Runtime/Windows/Boottime.php
+++ b/src/Runtime/Windows/Boottime.php
@@ -6,13 +6,34 @@ use Uptime\Runtime\RuntimeInterface;
 
 class Boottime implements RuntimeInterface
 {
-
+    /**
+     * Reads the wmic command which returns the last bootup time and converts it to a unix timestamp
+     *
+     * @param string $command wmic command
+     * @return int
+     */
     public function read($command = 'wmic os get lastbootuptime')
     {
+        $wmicString = trim(explode("\n", shell_exec($command))[1]);
+
         $dateTime = \DateTime::createFromFormat(
             'YmdHis.uO',
-            trim( explode( "\n", shell_exec($command) )[1] )
+            $this->convertWmicOffset($wmicString)
         );
         return $dateTime->getTimestamp();
+    }
+
+    /**
+     * Takes the output of wmic os get lastbootuptime and converts the offset given in minutes to an HHMM offset acceptable by PHP createFromFormat 'O'
+     *
+     * @param string $wmicString string output given by wmic command
+     * @return string
+     */
+    private function convertWmicOffset($wmicString)
+    {
+        $offset = substr($wmicString, -3);
+        $hours = floor($offset / 60);
+        $minutes = ($offset % 60);
+        return substr($wmicString, 0, -3) . sprintf('%02d%02d', $hours, $minutes);
     }
 }

--- a/test/Runtime/Windows/BoottimeTest.php
+++ b/test/Runtime/Windows/BoottimeTest.php
@@ -27,9 +27,47 @@ class BoottimeTest extends \PHPUnit_Framework_TestCase
         };
 
         return [
-            $factory(1398820256, '20140429225056.153625-180', "LastBootUpTime\n%s\n\n\n"),
+            $factory(1398822656, '20140429225056.153625-180', "LastBootUpTime\n%s\n\n\n"),
             $factory(1339509056, '20120612125056.153625-060', "LastBootUpTime\n%s\n\n\n"),
-            $factory(1379775724, '20130921162204.153625+120', "LastBootUpTime\n%s\n\n\n"),
+            $factory(1379773324, '20130921162204.153625+120', "LastBootUpTime\n%s\n\n\n"),
         ];
+    }
+
+    /**
+     * Test for different timezones
+     *
+     * Last 3 digits of wmic returns a timezone offset in minutes (+ or -)
+     *
+     * @return void
+     */
+    public function testTimeZones()
+    {
+        $timeString = '20160607160855.488750';
+        $utTime = new \DateTime('2016-06-07 16:08:55', new \DateTimeZone('utc'));
+        $boottime = new Boottime();
+
+        // Positive timezone offsets
+        for ($i = 0; $i <= 12; ++$i) {
+            $expectedTime = clone $utTime;
+            $expectedTime->modify("-$i hour");
+            $offset = sprintf('%03d', $i * 60);
+
+            $this->assertSame(
+                $boottime->read("echo ; echo '{$timeString}+{$offset}'"),
+                $expectedTime->getTimestamp()
+            );
+        }
+
+        // Negative timezone offsets
+        for ($i = 0; $i <= 12; ++$i) {
+            $expectedTime = clone $utTime;
+            $expectedTime->modify("+$i hour");
+            $offset = sprintf('%03d', $i * 60);
+
+            $this->assertSame(
+                $boottime->read("echo ; echo '{$timeString}-{$offset}'"),
+                $expectedTime->getTimestamp()
+            );
+        }
     }
 }


### PR DESCRIPTION
I realised that there was a flaw in the previous logic. createFromFormat() 'O' expects an offset in HHMM format and wmic returns it as minutes.

The code worked fine for +060 (UTC+1 hour/British Summer Time) but when we tried it in New York (+240), this was incorrectly interpreting it as 2 hours 4 minutes rather than UTC-4 hours!
